### PR TITLE
Fix no existing col and decimal columns

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "target-iceberg"
-version = "0.0.2"
+version = "1.0.3"
 description = "Singer target for iceberg, built with the Meltano Singer SDK."
 readme = "README.md"
 authors = [{ name = "Jarosław Cellary", email = "jcellary@gmail.com" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "target-iceberg"
-version = "0.0.1"
+version = "0.0.2"
 description = "Singer target for iceberg, built with the Meltano Singer SDK."
 readme = "README.md"
 authors = [{ name = "Jarosław Cellary", email = "jcellary@gmail.com" }]

--- a/target_iceberg/sinks.py
+++ b/target_iceberg/sinks.py
@@ -84,7 +84,7 @@ class IcebergSink(BatchSink):
             )
         )
         for old_name, new_name in self.column_renames.items():
-            record_flatten[new_name] = record_flatten.pop(old_name)
+            record_flatten[new_name] = record_flatten.pop(old_name, None)
         if not self.skip_add_synced_field:
             record_flatten = record_flatten | { "synced_ms": self.start_time }
         super().process_record(record_flatten, context)

--- a/target_iceberg/utils.py
+++ b/target_iceberg/utils.py
@@ -78,7 +78,7 @@ def flatten_schema_to_pyarrow_schema(flatten_schema_dictionary: dict, column_ren
     )
 
 
-def _convert_decimal(value: Decimal):
+def _convert_decimal(value):
     """Convert Decimal"""
     if isinstance(value, Decimal):
         return float(value)

--- a/target_iceberg/utils.py
+++ b/target_iceberg/utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from decimal import Decimal
 
 import pyarrow as pa
 import re
@@ -77,7 +78,14 @@ def flatten_schema_to_pyarrow_schema(flatten_schema_dictionary: dict, column_ren
     )
 
 
+def _convert_decimal_to_str(value: Decimal):
+    """Convert Decimal to string."""
+    if isinstance(value, Decimal):
+        return str(value)
+    return value
+
+
 def create_pyarrow_table(list_dict: list[dict], schema: pa.Schema) -> pa.Table:
     """Create a pyarrow Table from a python list of dict."""
-    data = {f: [row.get(f) for row in list_dict] for f in schema.names}
+    data = {f: [_convert_decimal_to_str(row.get(f)) for row in list_dict] for f in schema.names}
     return pa.table(data).cast(schema)

--- a/target_iceberg/utils.py
+++ b/target_iceberg/utils.py
@@ -78,14 +78,14 @@ def flatten_schema_to_pyarrow_schema(flatten_schema_dictionary: dict, column_ren
     )
 
 
-def _convert_decimal_to_str(value: Decimal):
-    """Convert Decimal to string."""
+def _convert_decimal(value: Decimal):
+    """Convert Decimal"""
     if isinstance(value, Decimal):
-        return str(value)
+        return float(value)
     return value
 
 
 def create_pyarrow_table(list_dict: list[dict], schema: pa.Schema) -> pa.Table:
     """Create a pyarrow Table from a python list of dict."""
-    data = {f: [_convert_decimal_to_str(row.get(f)) for row in list_dict] for f in schema.names}
+    data = {f: [_convert_decimal(row.get(f)) for row in list_dict] for f in schema.names}
     return pa.table(data).cast(schema)


### PR DESCRIPTION
This PR will fix two issues:
- If there is an incomplete row (with not all fields), it crashes during rename, so we are forcing it to null if the field is not found.
- pyarrow table creation can crash before casting according to decimal value precision in the value (so we are converting them to float before creating the pyarrow table).
```
pyarrow.lib.ArrowInvalid: Decimal type with precision 7 does not fit into precision inferred from first array element: 8
```
