### PR TITLE
Added table name suffix and automatic rename of keywords

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "target-iceberg"
-version = "1.1.4"
+version = "1.1.5"
 description = "Singer target for iceberg, built with the Meltano Singer SDK."
 readme = "README.md"
 authors = [{ name = "Jarosław Cellary", email = "jcellary@gmail.com" }]

--- a/target_iceberg/sinks.py
+++ b/target_iceberg/sinks.py
@@ -67,10 +67,11 @@ class IcebergSink(BatchSink):
             snake_case_stream_name = table_renames.get(self.stream_name, table_renames.get('*', snake_case_stream_name))
 
         table_name_prefix = f"{self.config.get('table_name_prefix')}_" if self.config.get("table_name_prefix") else ""
+        table_name_suffix = f"_{self.config.get('table_name_suffix')}" if self.config.get("table_name_suffix") else ""
         if self.config.get('prod'):
-            return f"{self.config['db_name']}.{table_name_prefix}{snake_case_stream_name}"
+            return f"{self.config['db_name']}.{table_name_prefix}{snake_case_stream_name}{table_name_suffix}"
         else:
-            return f"scratch.{self.config['db_name']}__{table_name_prefix}{snake_case_stream_name}"
+            return f"scratch.{self.config['db_name']}__{table_name_prefix}{snake_case_stream_name}{table_name_suffix}"
 
     @cached_property
     def flatten_schema(self):

--- a/target_iceberg/sinks.py
+++ b/target_iceberg/sinks.py
@@ -17,6 +17,8 @@ from target_iceberg.utils import (create_pyarrow_table, flatten_schema_to_pyarro
 
 
 SYNCED_COLUMN_NAME = "synced_ms"
+# Automatically add _ suffix to columns which can break scala code generated definitions
+AUTOMATIC_COLUMN_RENAMES = {"public", "org", "private", "default", "schema", "uuid"}
 
 class IcebergSink(BatchSink):
     def __init__(self, target, schema, stream_name, key_properties) -> None:
@@ -83,8 +85,11 @@ class IcebergSink(BatchSink):
 
     @cached_property
     def column_renames(self) -> dict[str, str]:
+
         result = {key: re.sub(r'[\s\.,]+', '_', key).lower()
                                for key in self.flatten_schema.get("properties", {}).keys()}
+        result.update({key: f"{key}_" for key in self.flatten_schema.get("properties", {}).keys()
+                       if key in AUTOMATIC_COLUMN_RENAMES})
         result.update(process_json_config(
             self.config.get("column_renames", "{}"), config_name="column_renames", expected_type=dict))
         return {key: value for key, value in result.items() if key != value}

--- a/target_iceberg/target.py
+++ b/target_iceberg/target.py
@@ -41,7 +41,14 @@ class TargetIceberg(Target):
             "table_name_prefix",
             th.StringType,
             title="Table name prefix",
-            description="Additional table name prefix e.g. 'a4a' would result in a table name like 'my_db.a4a_raw_users'.",
+            description="Additional table name prefix e.g. 'a4a' would result in a table name like 'my_db.a4a_users'.",
+        ),
+        th.Property(
+            "table_name_suffix",
+            th.StringType,
+            title="Table name suffix",
+            description="Additional table name suffix e.g. 'tumblr' "
+                        "would result in a table name like 'my_db.users_tumblr'.",
         ),
         th.Property(
             "max_batch_size",

--- a/tests/test_sinks.py
+++ b/tests/test_sinks.py
@@ -10,7 +10,8 @@ from target_iceberg.utils import _field_type_to_pyarrow_field
 TEST_CONFIG = {"db_name": "test_db", "column_renames": '{ "old1": "new1", "old2": "new2" }',
                "upsert_data_for_streams": '["test"]', "deduplicate_data_for_streams": '["test"]',
                "primary_key_for_streams": '{ "test": ["new1"] }'}
-TEST_CONFIG_2 = {"db_name": "test_db", "table_renames": '{ "test": "test_renamed" }', "table_name_prefix": "raw"}
+TEST_CONFIG_2 = {"db_name": "test_db", "table_renames": '{ "test": "test_renamed" }', "table_name_prefix": "raw",
+                 "table_name_suffix": "suf"}
 TEST_CONFIG_3 = {"db_name": "test_db", "overwrite_data_for_streams": '["test"]', "prod": True}
 
 TEST_SCHEMA = {"properties": {
@@ -38,7 +39,7 @@ def test_initialization():
     assert sink.primary_key == ["new1"]
 
     sink = get_test_sink(TEST_CONFIG_2)
-    assert sink.table_name == "scratch.test_db__raw_test_renamed"
+    assert sink.table_name == "scratch.test_db__raw_test_renamed_suf"
 
     sink = get_test_sink(TEST_CONFIG_3)
     assert sink.overwrite_data == True

--- a/tests/test_sinks.py
+++ b/tests/test_sinks.py
@@ -15,6 +15,7 @@ TEST_CONFIG_2 = {"db_name": "test_db", "table_renames": '{ "test": "test_renamed
 TEST_CONFIG_3 = {"db_name": "test_db", "overwrite_data_for_streams": '["test"]', "prod": True}
 
 TEST_SCHEMA = {"properties": {
+        "public": {"type": "string"},
         "old1": {"type": "string"},
         "old2": {"type": "string"},
         "Co l": {"type": "string"},
@@ -32,7 +33,7 @@ def get_test_sink(config_base: dict, config_overwrites: dict = None):
 
 def test_initialization():
     sink = get_test_sink(TEST_CONFIG)
-    assert sink.column_renames == {'Co l': 'co_l', 'old1': 'new1', 'old2': 'new2'}
+    assert sink.column_renames == {'public': 'public_', 'Co l': 'co_l', 'old1': 'new1', 'old2': 'new2'}
     assert sink.table_name == "scratch.test_db__test"
     assert sink.upsert_data == True
     assert sink.deduplicate_data == True


### PR DESCRIPTION
Will be needed for zendesk as there are tables with `tumblr` suffix.