### PR TITLE
Remove extras from constraints file

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -61,7 +61,7 @@ pydantic-core==2.33.2
     # via pydantic
 pygments==2.19.2
     # via rich
-pyiceberg[hive]==0.9.1
+pyiceberg==0.9.1
     # via target-iceberg (pyproject.toml)
 pyparsing==3.2.3
     # via pyiceberg

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "target-iceberg"
-version = "1.1.7"
+version = "1.1.8"
 description = "Singer target for iceberg, built with the Meltano Singer SDK."
 readme = "README.md"
 authors = [{ name = "Jarosław Cellary", email = "jcellary@gmail.com" }]


### PR DESCRIPTION
> 2025-09-03T12:14:46.118482Z [error    ] Loader 'target-iceberg' could not be installed: Failed to install plugin 'target-iceberg'. details='Looking in indexes: [NEXUS_URL]/pypi/simple\nDEPRECATION: Constraints are only allowed to take the form of a package name and a version specifier. Other forms were originally permitted as an accident of the implementation, but were undocumented. The new implementation of the resolver no longer supports these forms. A possible replacement is replacing the constraint with a requirement. Discussion can be found at https://github.com/pypa/pip/issues/8210\nERROR: Constraints cannot have extras\n'

It looks like extras may not be supported in constraints? https://github.com/pypa/pip/issues/11599

Not sure how we want to proceed here.

# Testing
```
pip_url: git+https://github.com/Automattic/target-iceberg@fix/contraints --constraint https://raw.githubusercontent.com/Automattic/target-iceberg/fix/contraints/constraints.txt 
```
works for me in the test script and the job installs `target-iceberg` without errors.